### PR TITLE
Add ability to pass CLI arguments to optimizers

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -21,9 +21,14 @@ has the following signature:
 
 .. code-block:: python
 
-    function optimize(module, package=None):
+    function optimize(module, *args, **kwargs):
 
         pass
+
+This function will be run by the CLI tools to execute your optimization chain.
+The first argument with always be a `module.Module` object. The rest of the
+arguments are determined by the CLI. If your optimizer is configurable then
+you may add additional named arguments after 'module'.
 
 Now add a line like `pycc_my_optimizer = pycc.optimizers.my_optimizer:optimize`
 to the `pycc.optimizers` section in `setup.py`. The `pycc_` prefix is important
@@ -44,6 +49,13 @@ Finally, add a new argument to the parser in the `register` function of the
 
 The value of the `const` parameter should match the name you selected in the
 `pycc.optimizers` entry points from above.
+
+If you want to make a configuration value for your optimizer accessible as a
+CLI flag then you may add additional arguments to the parser. Just be sure to
+choose a name that is not so generic as to cause conflicts. All CLI arguments
+will be passed to your `optimize` function as keyword arguments. You can
+collect the values either through the `**kwargs` interface or by simply
+accepting a named parameter in the `optimize` function.
 
 Once you have this basic scaffolding set up you will be able to see your new
 optimizer flag in the command line scripts. As you add actual code you will be
@@ -110,9 +122,9 @@ Writing third party extensions that plug into the PyCC commands requires you
 to provide two interfaces on the right entry points.
 
 On the `pycc.optimizers` entry point you must expose a callable which accepts
-a `module.Module` object as the first parameter and an optional
-`module.Package` object as the second parameter. The name of this entry point
-must be prefixed with `pycc_`.
+a `module.Module` object as the first parameter, any number of named parameters
+which correspond with relevant CLI args added by your module, `*args`,
+and`**kwargs`. The name of this entry point must be prefixed with `pycc_`.
 
 On the `pycc.cli.args` entry point you must expose a callable which accepts
 an argument parser from `argparse`. Your function must use this parser to
@@ -130,3 +142,7 @@ register an argument as follows:
 
 The value of the `const` parameter should match exactly the name give to the
 `pycc.optimizers` entry point.
+
+You may also register arguments needed to configure your optimizer. They will
+be passed into your `pycc.optimizers` entry point addition as keyword
+arguments.

--- a/pycc/cli/compile.py
+++ b/pycc/cli/compile.py
@@ -43,13 +43,13 @@ def make_pyc(module, destination):
         pyc.write(py_compile.MAGIC)
 
 
-def main_module(path, optimizers, destination):
+def main_module(path, optimizers, destination, args):
 
     mod = loader.ModuleLoader(path).load()
 
     for optimizer in optimizers:
 
-        optimizer(mod)
+        optimizer(mod, **args.__dict__)
 
     make_pyc(
         mod,
@@ -60,7 +60,7 @@ def main_module(path, optimizers, destination):
     )
 
 
-def main_package(path, optimizers, destination):
+def main_package(path, optimizers, destination, args):
 
     pkg = loader.PackageLoader(path).load()
 
@@ -75,7 +75,7 @@ def main_package(path, optimizers, destination):
 
         for optimizer in optimizers:
 
-            optimizer(mod, package=pkg)
+            optimizer(mod, **args.__dict__)
 
         output_path = mod.path + ".pyc"
 
@@ -122,11 +122,11 @@ def main():
 
     if os.path.isdir(path):
 
-        main_package(path, optimizers, destination)
+        main_package(path, optimizers, destination, args)
 
     else:
 
-        main_module(path, optimizers, destination)
+        main_module(path, optimizers, destination, args)
 
 
 if __name__ == '__main__':

--- a/pycc/cli/transform.py
+++ b/pycc/cli/transform.py
@@ -16,23 +16,23 @@ def parse_args():
     return parser.parse_args()
 
 
-def main_module(path, optimizers):
+def main_module(path, optimizers, args):
 
     mod = loader.ModuleLoader(path).load()
 
     for optimizer in optimizers:
-        optimizer(mod)
+        optimizer(mod, **args.__dict__)
 
     print SourceCodeRenderer.render(mod.node)
 
 
-def main_package(path, optimizers):
+def main_package(path, optimizers, args):
 
     pkg = loader.PackageLoader(path).load()
 
     for mod in pkg.modules():
         for optimizer in optimizers:
-            optimizer(mod, package=pkg)
+            optimizer(mod, **args.__dict__)
 
         print SourceCodeRenderer.render(mod.node)
 
@@ -53,11 +53,11 @@ def main():
 
     if os.path.isdir(path):
 
-        main_package(path, optimizers)
+        main_package(path, optimizers, args)
 
     else:
 
-        main_module(path, optimizers)
+        main_module(path, optimizers, args)
 
 
 if __name__ == '__main__':

--- a/pycc/optimizers/constant.py
+++ b/pycc/optimizers/constant.py
@@ -232,7 +232,7 @@ class ConstantInliner(base.Transformer, ast.NodeTransformer):
         return self.generic_visit(node)
 
 
-def optimize(module):
+def optimize(module, *args, **kwargs):
     """Run the optimization chain for constant value inlining."""
 
     found = ConstantFinder(module)()


### PR DESCRIPTION
The CLI tools now pass all CLI args in to the optimizer entry
points as keyword arguments. This makes it possible to expose
optimizer configuration values through the CLI.

Signed-off-by: Kevin Conway kevinjacobconway@gmail.com
